### PR TITLE
Windows Paths Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ function gatherBuildResources(percyClient, buildDir) {
         var absolutePath = path.join(root, fileStats.name);
         var resourceUrl = absolutePath.replace(buildDir, '');
 
-		// Replace backslashes for forwards slashes to resolve run issues on Windows hosts.		
-		resourceUrl = resourceUrl.replace('\\', '/');
+        // Replace backslashes for forwards slashes to resolve run issues on Windows hosts.		
+        resourceUrl = resourceUrl.replace('\\', '/');
 
         for (var i in SKIPPED_ASSETS) {
           if (resourceUrl.match(SKIPPED_ASSETS[i])) {

--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ function gatherBuildResources(percyClient, buildDir) {
         var absolutePath = path.join(root, fileStats.name);
         var resourceUrl = absolutePath.replace(buildDir, '');
 
+		// Replace backslashes for forwards slashes to resolve run issues on Windows hosts.		
+		resourceUrl = resourceUrl.replace('\\', '/');
+
         for (var i in SKIPPED_ASSETS) {
           if (resourceUrl.match(SKIPPED_ASSETS[i])) {
             next();

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function gatherBuildResources(percyClient, buildDir) {
         var absolutePath = path.join(root, fileStats.name);
         var resourceUrl = absolutePath.replace(buildDir, '');
 
-        if (path.sep == '/') {
+        if (path.sep == '\\') {
           // Windows support: transform filesystem backslashes into forward-slashes for the URL.
           resourceUrl = resourceUrl.replace('\\', '/');
         }

--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@ function gatherBuildResources(percyClient, buildDir) {
         var absolutePath = path.join(root, fileStats.name);
         var resourceUrl = absolutePath.replace(buildDir, '');
 
-        // Replace backslashes for forwards slashes to resolve run issues on Windows hosts.		
-        resourceUrl = resourceUrl.replace('\\', '/');
+        if (path.sep == '/') {
+          // Windows support: transform filesystem backslashes into forward-slashes for the URL.
+          resourceUrl = resourceUrl.replace('\\', '/');
+        }
 
         for (var i in SKIPPED_ASSETS) {
           if (resourceUrl.match(SKIPPED_ASSETS[i])) {


### PR DESCRIPTION
Convert backslashes into forward slashes in the resourceUrl to support running Percy on a Windows host.

As per a conversation with one of my colleagues, we've added the line suggested to resolve the bug running ember in development on a windows host. This appears to work as expected for us!