### PR TITLE
Delete the `_originalThrowUnmocked` property

### DIFF
--- a/addon/mockjax-wrapper.js
+++ b/addon/mockjax-wrapper.js
@@ -11,5 +11,6 @@ export function maybeDisableMockjax() {
 export function maybeResetMockjax() {
   if (window.jQuery && window.jQuery.mockjaxSettings && window.jQuery.mockjaxSettings._originalThrowUnmocked) {
      window.jQuery.mockjaxSettings.throwUnmocked = window.jQuery.mockjaxSettings._originalThrowUnmocked;
+     delete window.jQuery.mockjaxSettings._originalThrowUnmocked;
   }
 }


### PR DESCRIPTION
Ran into an issue when running a mixed set of tests using mockjax and `ember-cli-mirage`.

The gist of the issue is as follows:

* Run a test with a percy snapshot in which `throwUnmocked` is set to true (i.e. not using `ember-cli-mirage`).
* Follow that with a test in which `throwUnmocked` was set to false (initially, i.e. using `ember-cli-mirage`).
* When `maybeResetMockjax` is called in the second test, it will set the `throwUnmocked` property back to true, which will cause requests expected to be handled by `ember-cli-mirage` to fail.