### PR TITLE
Fix DOM snapshot depth bug.

### DIFF
--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -38,10 +38,10 @@ export function percySnapshot(name, options) {
   // Create a full-page DOM snapshot from the current testing page.
   // TODO(fotinakis): more memory-efficient way to do this?
   let domCopy = Ember.$('html').clone();
-  let testingContainer = domCopy.find('#ember-testing-container');
+  let testingContainer = domCopy.find('#ember-testing');
 
   if (scope) {
-    snapshotHtml = Ember.$('#ember-testing-container').find(scope).html();
+    snapshotHtml = Ember.$('#ember-testing').find(scope).html();
   } else {
     snapshotHtml = testingContainer.html();
   }


### PR DESCRIPTION
We were incorrectly capturing DOM contents 1 level too high, so the resulting DOM snapshot happened to contain a wrapping `ember-testing` div. This hasn't been a problem up until now, but a customer just reported a 100% height bug which ended up being traced to that wrapping div being included.