### PR TITLE
Encode resource url and update to percy-client 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function gatherBuildResources(percyClient, buildDir) {
         var sha = crypto.createHash('sha256').update(content).digest('hex');
 
         var resource = percyClient.makeResource({
-          resourceUrl: resourceUrl,
+          resourceUrl: encodeURI(resourceUrl),
           sha: sha,
           localPath: absolutePath,
         });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "body-parser": "^1.15.0",
     "ember-cli-babel": "^5.1.5",
     "es6-promise-pool": "^2.4.1",
-    "percy-client": "^1.3.0",
+    "percy-client": "^2.0.0",
     "walk": "^2.3.9"
   },
   "ember-addon": {


### PR DESCRIPTION
https://github.com/percy/percy-js/pull/4 needs to be merged and released first.