### PR TITLE
Fix Windows path support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function gatherBuildResources(percyClient, buildDir) {
 
         if (path.sep == '\\') {
           // Windows support: transform filesystem backslashes into forward-slashes for the URL.
-          resourceUrl = resourceUrl.replace('\\', '/');
+          resourceUrl = resourceUrl.replace(/\\/g, '/');
         }
 
         for (var i in SKIPPED_ASSETS) {


### PR DESCRIPTION
Before:
```node
> encodeURI("\\some\\windows\\path.css".replace('\\', '/'))
'/some%5Cwindows%5Cpath.css'
```

After:
```node
> encodeURI("\\some\\windows\\path.css".replace(/\\/g, '/'))
'/some/windows/path.css'
```