### PR TITLE
Fix support for Ember rootURL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PERCY_ENABLE=0 EMBER_TRY_SCENARIO=ember-beta
     - env: PERCY_ENABLE=0 EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ function gatherBuildResources(percyClient, buildDir) {
           resourceUrl = resourceUrl.replace(/\\/g, '/');
         }
 
+        // Append the Ember rootURL if it exists.
+        resourceUrl = normalizedRootUrl + resourceUrl;
+
         for (var i in SKIPPED_ASSETS) {
           if (resourceUrl.match(SKIPPED_ASSETS[i])) {
             next();
@@ -101,6 +104,7 @@ function handlePercyFailure(error) {
 // TODO: refactor to break down into a more modular design with less global state.
 var percyClient;
 var percyConfig;
+var normalizedRootUrl;
 var percyBuildPromise;
 var seenSnapshotNames = [];
 var buildResourceUploadPromises = [];
@@ -120,6 +124,9 @@ module.exports = {
   // Grab and store the `percy` config set in an app's config/environment.js.
   config: function(env, baseConfig) {
     percyConfig = baseConfig.percy || {};
+
+    // Store the Ember rootURL without a trailing slash, or a blank string.
+    normalizedRootUrl = (baseConfig.rootURL || '/').replace(/\/$/, '');
 
     // Make sure the percy config has a 'breakpoints' object.
     percyConfig.breakpointsConfig = percyConfig.breakpointsConfig || {};

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    rootURL: '/',
+    rootURL: '/test-root-url/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2887,7 +2887,7 @@ glob@7.0.6, glob@^7.0.4, glob@^7.0.5, glob@~7.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.10:
+glob@^5.0.10, glob@~5.0.0:
   version "5.0.13"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.13.tgz#0b6ffc3ac64eb90669f723a00a0ebb7281b33f8f"
   dependencies:
@@ -2897,7 +2897,7 @@ glob@^5.0.10:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.15, glob@~5.0.0:
+glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:


### PR DESCRIPTION
Tested: non-existent rootURL, default rootURL `/`, and `/test-root-url` (which Ember throws an error for) and `/test-root-url/`.