### PR TITLE
Prepare addon for FastBoot 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,11 +149,6 @@ module.exports = {
   },
   // After build output is ready, create a Percy build and upload missing build resources.
   outputReady: function(result) {
-    // Disable Percy when running Fastboot builds (for now).
-    if (typeof process.env.EMBER_CLI_FASTBOOT !== 'undefined') {
-      return;
-    }
-
     var token = process.env.PERCY_TOKEN;
     var apiUrl = process.env.PERCY_API; // Optional.
     var environment = new Environment(process.env);


### PR DESCRIPTION
Prepares for upcoming release of FastBoot 1.0: ember-fastboot/ember-cli-fastboot#387 . I don't know how this addon works really so please make sure to test it with ember-cli-fastboot rc builds before merging. 

You may want to do a major version bump since this will not work on beta releases.