### PR TITLE
Allow capturing the content of Ember textareas - fixes #35

### DIFF
--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -38,6 +38,19 @@ function setAttributeValues(dom) {
   return dom;
 }
 
+// `Ember.TextArea` sets its content by updating `HTMLTextAreaElement.value` directly
+// This doesn't update the actual text content and so the clone shows up blank - by copying
+// `HTMLTextAreaElement.value` to `Node.textContent`, the percy snapshot is able to include
+// the current value for the textarea
+function setTextareaContent(dom) {
+  dom.find('textarea').each(function() {
+    let elem = Ember.$(this);
+    elem.text(elem.val());
+  });
+
+  return dom;
+}
+
 export function percySnapshot(name, options) {
   // Skip if Testem is not available (we're probably running from `ember server` and Percy is not
   // enabled anyway).
@@ -68,7 +81,10 @@ export function percySnapshot(name, options) {
     snapshotRoot = testingContainer;
   }
 
-  let snapshotHtml = setAttributeValues(snapshotRoot).html();
+  snapshotRoot = setAttributeValues(snapshotRoot);
+  snapshotRoot = setTextareaContent(snapshotRoot);
+
+  let snapshotHtml = snapshotRoot.html();
 
   // Hoist the testing container contents up to the body.
   // We need to use the original DOM to keep the head stylesheet around.

--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -38,10 +38,7 @@ function setAttributeValues(dom) {
   return dom;
 }
 
-// `Ember.TextArea` sets its content by updating `HTMLTextAreaElement.value` directly
-// This doesn't update the actual text content and so the clone shows up blank - by copying
-// `HTMLTextAreaElement.value` to `Node.textContent`, the percy snapshot is able to include
-// the current value for the textarea
+// jQuery clone() does not copy textarea contents, so we explicitly do it here.
 function setTextareaContent(dom) {
   dom.find('textarea').each(function() {
     let elem = Ember.$(this);

--- a/tests/integration/components/dummy-box-test.js
+++ b/tests/integration/components/dummy-box-test.js
@@ -68,3 +68,12 @@ test('it snapshots radio button values', function(assert) {
   assert.equal(this.$('input')[0].checked, true, 'radio button is checked');
   percySnapshot('checkbox with check');
 });
+
+test('it snapshots textarea values', function(assert) {
+  this.render(hbs`{{textarea value="Testing"}}`);
+
+  assert.equal(this.$('textarea')[0].value, 'Testing', 'value property is set');
+  assert.equal(this.$('textarea').text(), '', 'text content is not set');
+
+  percySnapshot('textarea with value');
+});


### PR DESCRIPTION
This allows the content of textareas to be captured in percy snapshots, importantly though **this can only work in browsers where `Ember.TextArea` actually works** (so far it seems to not work in PhantomJS, and has been shown to work as expected in Chrome).

I'm not sure if a note needs adding to the README about this browser-based limitation for textareas, but this PR does at least allow snapshots taken from a suitable browser to capture the textarea content.