### PR TITLE
Initial ember-exam compatibility.

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,11 +444,6 @@ module.exports = {
             percyClient.finalizeBuild(percyBuildData.id).then(function() {
               sendResponse(true);
 
-              // Avoid trying to add snapshots to an already-finalized build. This might happen when
-              // running tests locally and the browser gets refreshed after the end of a test run.
-              // Generally, this is not a problem because tests only run in CI and only once.
-              isPercyEnabled = false;
-
               // Attempt to make our logging come last, giving time for test output to finish.
               var url = percyBuildData.attributes['web-url'];
               process.nextTick(function() {


### PR DESCRIPTION
Removes an unnecessary line that was preventing ember-exam compatibility.

### Before

After the build was finalized, we flipped an internal flag called `isPercyEnabled` to false, so that no more Percy actions would be taken. In ember-exam world, even if `PERCY_PARALLEL_TOTAL` and `PERCY_PARALLEL_NONCE` were set up correctly, this would prematurely turn off ember-percy before all finalize calls were accounted for.

### After

Remove the flag flipping after finalizing builds, now you can safely run something like:

```bash
$ export PERCY_PARALLEL_TOTAL=4
$ export PERCY_PARALLEL_NONCE=foo-`date +%Y-%m-%d-%H%M%S`
$ ember exam --split=4 --parallel
```

### Compatibility

This is technically backwards-compatible if someone has tokens exposed locally and runs tests multiple times (rare), they'll just see logging output like:

```
[percy][ERROR] API call failed, Percy has been disabled for this build.
StatusCodeError: 409 - {"errors":[{"status":"conflict","detail":"Can only create snapshots in pending builds."}]}
```