### PR TITLE
Support decoupled `build` and `test` steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,13 +301,15 @@ module.exports = {
     // was (presumably) called during the `ember build` step.
     // This covers the case where tests are run via
     // `ember build --environment=test --output-path=foo && ember test --path=foo`
-    if (!percyBuildPromise && process.env.EMBER_CLI_TEST_COMMAND === 'true' && process.env.EMBER_CLI_TEST_OUTPUT) {
-      this.outputReady({ directory: process.env.EMBER_CLI_TEST_OUTPUT });
-    } else {
-      console.warn(
-        '[percy][WARNING] No percy build available, and there isn\'t enough information to make one.'
-      );
-      isPercyEnabled = false;
+    if (!percyBuildPromise) {
+      if (process.env.EMBER_CLI_TEST_COMMAND === 'true' && process.env.EMBER_CLI_TEST_OUTPUT) {
+        this.outputReady({ directory: process.env.EMBER_CLI_TEST_OUTPUT });
+      } else {
+        console.warn(
+          '[percy][WARNING] No percy build available, and there isn\'t enough information to make one.'
+        );
+        isPercyEnabled = false;
+      }
     }
     // Add middleware to add request.body because it is not populated in express by default.
     app.use(bodyParser.json({limit: '50mb'}));

--- a/index.js
+++ b/index.js
@@ -292,6 +292,18 @@ module.exports = {
   },
 
   testemMiddleware: function(app) {
+    // some special-case logic for when `ember test` is invoked with the `--path=foo`
+    // flag.  `ember-cli` doesn't expose command arguments to addons, but does
+    // set the `EMBER_CLI_TEST_OUTPUT` env variable to the value of the `--path` option.
+    // `ember-cli` also apparently sets `EMBER_CLI_TEST_COMMAND` to `true` when
+    // running `ember test`.
+    // Under these conditions, the `outputReady` step is never called, because it
+    // was (presumably) called during the `ember build` step.
+    // This covers the case where tests are run via
+    // `ember build --environment=test --output-path=foo && ember test --path=foo`
+    if (!percyBuildPromise && process.env.EMBER_CLI_TEST_COMMAND === 'true' && process.env.EMBER_CLI_TEST_OUTPUT) {
+      this.outputReady({ directory: process.env.EMBER_CLI_TEST_OUTPUT });
+    }
     // Add middleware to add request.body because it is not populated in express by default.
     app.use(bodyParser.json({limit: '50mb'}));
 

--- a/index.js
+++ b/index.js
@@ -303,6 +303,11 @@ module.exports = {
     // `ember build --environment=test --output-path=foo && ember test --path=foo`
     if (!percyBuildPromise && process.env.EMBER_CLI_TEST_COMMAND === 'true' && process.env.EMBER_CLI_TEST_OUTPUT) {
       this.outputReady({ directory: process.env.EMBER_CLI_TEST_OUTPUT });
+    } else {
+      console.warn(
+        '[percy][WARNING] No percy build available, and there isn\'t enough information to make one.'
+      );
+      isPercyEnabled = false;
     }
     // Add middleware to add request.body because it is not populated in express by default.
     app.use(bodyParser.json({limit: '50mb'}));


### PR DESCRIPTION
This fix supports an unusual edge case centering on decomposing the `ember test` step into `ember build --environment=test --output-path=<path>` and `ember test --path=<path>` steps.

The easiest way to reproduce this is to simply run the above commands:

* `ember build --environment=test --output-path=./.test`
* `EMBER_ENV=test ember test --path=./.test`

Note: that the `EMBER_ENV` variable is important.  Without a build step, `ember-cli` (at least as of `ember-cli@v2.8.0`) does not set the `EMBER_ENV` variable, which eventually results in the `config` hook receiving the default application configuration, rather than the `test` configuration.  If the default application configuration sets the proper `percy` configuration, this can be skipped.

The fix here is to attempt to reconstruct the necessary information from "hidden" environment variables set by `ember-cli`: `EMBER_CLI_TEST_OUTPUT` being the important one.

If `percyBuildPromise` doesn't exist, and it cannot be reconstructed from available environment variables, this now prints a warning and disables percy.