### PR TITLE
Support ember test using a pre-built app

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = {
 
   // Create a Percy build and upload missing build resources.
   createPercyBuild: function(buildOutputDirectory) {
-    this.createPercyBuildInvoked = true;
+    createPercyBuildInvoked = true;
 
     var token = process.env.PERCY_TOKEN;
     var apiUrl = process.env.PERCY_API; // Optional.
@@ -314,7 +314,7 @@ module.exports = {
     // The value passed to --path is available in process.env.EMBER_CLI_TEST_OUTPUT
     // We can also check we're executing the test command with process.env.EMBER_CLI_TEST_COMMAND
 
-    if (!this.createPercyBuildInvoked) {
+    if (!createPercyBuildInvoked) {
       if (process.env.EMBER_CLI_TEST_COMMAND === 'true' && process.env.EMBER_CLI_TEST_OUTPUT) {
         this.createPercyBuild(process.env.EMBER_CLI_TEST_OUTPUT);
       } else {

--- a/index.js
+++ b/index.js
@@ -186,8 +186,10 @@ module.exports = {
     }
   },
 
-  // After build output is ready, create a Percy build and upload missing build resources.
+
   outputReady: function(result) {
+    // outputReady is run both in `ember build` and in `ember test` when a build is completed.
+    // Only create a Percy Build in the `ember test` context. Tests aren't run for `ember build`.
     if (process.env.EMBER_CLI_TEST_COMMAND === 'true') {
       this.createPercyBuild(result.directory);
     }


### PR DESCRIPTION
This change enables Percy to run correctly when `ember test --dist=foo` is used, and ember test is supplied with a prebuilt app.

Credit and a big thank you to @DeviateFish for [figuring out the solution](https://github.com/percy/ember-percy/pull/43).

### To reproduce the failure that this PR fixes:
```
cd ember-app
export PERCY_VARS
ember build -o dist
ember test --path=dist
```
Results in an unsuccessful build.

### Usage to be documented after this PR is merged:
```
cd ember-app
export PERCY_VARS
ember build --environment=test -o dist
EMBER_ENV=test ember test --path=dist
```
Note: that the EMBER_ENV variable is important. Without a build step, ember-cli (at least as of ember-cli@v2.8.0) does not set the EMBER_ENV variable, which eventually results in the config hook receiving the default application configuration, rather than the test configuration.

### Supported ember versions
Ember 1.13.9 and later is supported.

- EMBER_CLI_TEST_COMMAND has been present since < 1.11.
- EMBER_CLI_TEST_OUTPUT has been present since ember-cli 0.2.4 which was ember 1.12
- outputReady has been present since 1.13.9 (ember-cli)

### Tested on an Ember 2.10 app:

- [x] Uploads successful build with `ember-test` with no --dist flag (current usage)
- [x] No output and no Percy build created when `ember build` invoked without a --dist flag
- [x] No output and no Percy build created when `ember build` invoked with a --dist flag
- [x] No output and no Percy build created when `ember test` invoked with a --dist flag and PERCY_ENABLE=0.
- [x] When `ember test` invoked with a --dist flag, correctly created build.
- [x] When `ember test` invoked with a --dist flag and ember exam split builds, correctly created build.
