### PR TITLE
Use afterTests to call finalize

### DIFF
--- a/addon/finalize.js
+++ b/addon/finalize.js
@@ -5,7 +5,7 @@ import { maybeDisableMockjax, maybeResetMockjax } from './mockjax-wrapper';
 // Percy finalizer to be called at the very end of the test suite.
 // Note: it is important that this is called always, no matter if percySnapshot was used or not,
 // to support parallelized test runners with Percy's aggregation of parallel finalize calls.
-function finalizeBuildOnce() {
+function finalizeBuildOnce(config, data, callback) {
   maybeDisableMockjax();
   let options = {
     xhr: getNativeXhr,
@@ -16,15 +16,19 @@ function finalizeBuildOnce() {
     async: false,
     timeout: 30000,
   };
-  Ember.$.ajax('/_percy/finalize_build', options);
+  Ember.$.ajax('/_percy/finalize_build', options)
+    .done( () => {
+      if(callback) {
+        callback();
+      }
+    });
   maybeResetMockjax();
 }
 
 // When imported into test-body-footer, register Testem hook to know when all tests are finished.
 export default function() {
   if (window.Testem.afterTests) {
-    // Testem >= v1.6.0. (We should just use afterTests, but it does not work as expected).
-    window.Testem.on('after-tests-complete', finalizeBuildOnce);
+    window.Testem.afterTests(finalizeBuildOnce);
   } else {
     // Testem < v1.6.0.
     window.Testem.on('all-test-results', finalizeBuildOnce);


### PR DESCRIPTION
This ensures finalize is only invoked once per test run.  

One of our customers had been experiencing a problem where the 'after-tests-complete' event was fired multiple times, invoking finalize multiple times - and breaking parallelized builds.  This solves that problem.