### PR TITLE
Use new ember modules API

### DIFF
--- a/addon/finalize.js
+++ b/addon/finalize.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { getNativeXhr } from './native-xhr';
 import { maybeDisableMockjax, maybeResetMockjax } from './mockjax-wrapper';
 
@@ -16,7 +16,7 @@ function finalizeBuildOnce(config, data, callback) {
     async: false,
     timeout: 30000,
   };
-  Ember.$.ajax('/_percy/finalize_build', options)
+  $.ajax('/_percy/finalize_build', options)
     .done( () => {
       if(callback) {
         callback();

--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import $ from 'jquery';
 import { getNativeXhr } from './native-xhr';
 import { maybeDisableMockjax, maybeResetMockjax } from './mockjax-wrapper';
 
@@ -26,8 +27,8 @@ function setAttributeValues(dom) {
      input[type=password], input[type=number], input[type=checkbox], input[type=radio]`
   );
 
-  Ember.$(elems).each(function() {
-    let elem = Ember.$(this);
+  $(elems).each(function() {
+    let elem = $(this);
     switch(elem.attr('type')) {
       case 'checkbox':
       case 'radio':
@@ -46,7 +47,7 @@ function setAttributeValues(dom) {
 // jQuery clone() does not copy textarea contents, so we explicitly do it here.
 function setTextareaContent(dom) {
   dom.find('textarea').each(function() {
-    let elem = Ember.$(this);
+    let elem = $(this);
     elem.text(elem.val());
   });
 
@@ -74,7 +75,7 @@ export function percySnapshot(name, options) {
 
   // Create a full-page DOM snapshot from the current testing page.
   // TODO(fotinakis): more memory-efficient way to do this?
-  let domCopy = Ember.$('html').clone();
+  let domCopy = $('html').clone();
   let testingContainer = domCopy.find('#ember-testing');
 
   if (scope) {
@@ -92,9 +93,9 @@ export function percySnapshot(name, options) {
   // We need to use the original DOM to keep the head stylesheet around.
   domCopy.find('body').html(snapshotHtml);
 
-  Ember.run(function() {
+  run(function() {
     maybeDisableMockjax();
-    Ember.$.ajax('/_percy/snapshot', {
+    $.ajax('/_percy/snapshot', {
       xhr: getNativeXhr,
       method: 'POST',
       contentType: 'application/json; charset=utf-8',

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,11 +1,11 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/components/dummy-box.js
+++ b/tests/dummy/app/components/dummy-box.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['DummyBox']
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
+import { Promise } from 'rsvp';
 import { module } from 'qunit';
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 import './percy/register-helpers';
@@ -6,10 +7,10 @@ import './percy/register-helpers';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();


### PR DESCRIPTION
ember-percy didn't work on without this on one of my projects, probably because I removed `ember-cli-shims`.