### PR TITLE
TypeScript ambient type information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,31 @@
+
+interface QUnitAssert {
+  test: {
+    testName: string;
+    module: {
+      name: string;
+    }
+  }
+}
+
+interface MochaAssert {
+  fullTitle(): string
+}
+
+interface SnapshotOptions {
+  breakpoints?: string[];
+  scope?: string;
+  enableJavaScript?: boolean;
+  widths?: string[];
+}
+
+type SnapshotFunction = (
+  name: string | QUnitAssert | MochaAssert,
+  options?: SnapshotOptions
+) => Promise<void>;
+
+export const percySnapshot: SnapshotFunction;
+
+declare global {
+  const percySnapshot: SnapshotFunction;
+}


### PR DESCRIPTION
I've been using this ambient type information in apps, and it seems to be small, simple and stable enough to include in the addon for all users.

### Sample Cases
```ts
  percySnapshot('events-list'); // 👍
  percySnapshot('events-list-2', { breakpoints: ['desktop'] }); // 👍
  percySnapshot('events-list-4', { }); // 👍

  percySnapshot(); // 🛑 mandatory first arg (string)
  percySnapshot('events-list-2', { brkpoints: ['desktop'] });  // 🛑 unknown option name in second arg
  percySnapshot('events-list-2', { bad: 'arg', breakpoints: ['desktop'] }); // 🛑 unknown option name in second arg
```