### PR TITLE
Preserve body classes when hoisting element attributes

### DIFF
--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -66,10 +66,9 @@ function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
   let attributesToCopy = testingContainer.prop('attributes');
   $.each(attributesToCopy, function() {
     // Special case for the class attribute - append new classes onto existing body classes
-    if(this.name == 'class') {
+    if (this.name === 'class') {
       bodyCopy.attr(this.name, bodyCopy.attr('class') + ' ' + this.value);
-    }
-    else {
+    } else {
       bodyCopy.attr(this.name, this.value);
     }
   });

--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -60,23 +60,14 @@ function setTextareaContent(dom) {
 // Copy attributes from Ember's rootElement to the DOM snapshot <body> tag. Some applications rely
 // on setting attributes on the Ember rootElement (for example, to drive dynamic per-route
 // styling). In tests these attributes are added to the #ember-testing container and would be lost
-// in the DOM hoisting below, so we copy them to the to the snapshot's <body> tag to
+// in the DOM hoisting, so we copy them to the to the snapshot's <body> tag to
 // make sure that they persist in the DOM snapshot.
 function copyAttributesToBodyCopy(bodyCopy, testingContainer) {
   let attributesToCopy = testingContainer.prop('attributes');
   $.each(attributesToCopy, function() {
-    // Treat the class attribute as special - merge classes from the body and testingContainer
+    // Special case for the class attribute - append new classes onto existing body classes
     if(this.name == 'class') {
-      if(bodyCopy.attr('class') && this.value) {
-        let bodyClasses = bodyCopy.attr('class').split(' ');
-        let testingContainerClasses = this.value.split(' ');
-        testingContainerClasses.forEach(function(className) {
-          if(!bodyClasses.includes(className)) {
-            bodyClasses.push(className);
-          }
-        })
-        bodyCopy.attr('class', bodyClasses.join(' '));
-      }
+      bodyCopy.attr(this.name, bodyCopy.attr('class') + ' ' + this.value);
     }
     else {
       bodyCopy.attr(this.name, this.value);

--- a/tests/acceptance/dummy-test.js
+++ b/tests/acceptance/dummy-test.js
@@ -51,3 +51,13 @@ test('attributes on rootElement are copied to the DOM snapshot', function(assert
   });
   percySnapshot(assert);
 });
+
+test('class on body that turns it green is preserved the DOM snapshot', function(assert) {
+  visit('/');
+  // find('body').attr('class', 'all-green');
+  console.log(find('body'));
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+  });
+  percySnapshot(assert);
+});

--- a/tests/acceptance/dummy-test.js
+++ b/tests/acceptance/dummy-test.js
@@ -54,10 +54,16 @@ test('attributes on rootElement are copied to the DOM snapshot', function(assert
 
 test('class on body that turns it green is preserved the DOM snapshot', function(assert) {
   visit('/');
-  // find('body').attr('class', 'all-green');
-  console.log(find('body'));
+  // find's default scope is the testing container, so be sure to rescope to html
+  let body = find('body', 'html');
+  body.attr('class', 'AllGreen');
   andThen(function() {
     assert.equal(currentURL(), '/');
   });
   percySnapshot(assert);
+  assert.equal(body.attr('class').includes('AllGreen'), true);
+  // Remove AllGreen so it doesn't impact other tests
+  andThen(function() {
+    body.attr('class', '');
+  });
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -2,6 +2,10 @@ body {
   font-size: 26px;
 }
 
+.AllGreen {
+  background: green;
+}
+
 .DummyBox {
   background: lightblue;
   padding: 20px;


### PR DESCRIPTION
Currently when element attributes are hoisted to the body, classes are overwritten.  Instead of overwriting them, append to them.  This will preserve any styling that's applied via classes on the body.