### PR TITLE
Use old import syntax for registerAsyncHelper

### DIFF
--- a/test-support/helpers/percy/register-helpers.js
+++ b/test-support/helpers/percy/register-helpers.js
@@ -1,7 +1,7 @@
 import { percySnapshot } from 'ember-percy';
 import Ember from 'ember';
 
-Ember.Test.registerAsyncHelper('percySnapshot', function(app, name, options) {
+Ember.Test.registerAsyncHelper('percySnapshot', function(app, name, options) { // eslint-disable-line
   percySnapshot(name, options);
 });
 

--- a/test-support/helpers/percy/register-helpers.js
+++ b/test-support/helpers/percy/register-helpers.js
@@ -1,7 +1,7 @@
 import { percySnapshot } from 'ember-percy';
-import { registerAsyncHelper } from '@ember/test';
+import Ember from 'ember';
 
-registerAsyncHelper('percySnapshot', function(app, name, options) {
+Ember.Test.registerAsyncHelper('percySnapshot', function(app, name, options) {
   percySnapshot(name, options);
 });
 


### PR DESCRIPTION
I don't know why this didn't work or why it fixes it, but running `yarn test` with `ember-percy` `yarn link`ed to `example-ember` repo worked. Also upgraded `example-ember` to 2.18 and ran the tests, which also passed.

Also `yarn link`ed this version of `ember-percy` to `percy-web` and ran the tests which also worked.

But the Travis tests still don't fail...