### PR TITLE
npmignore: Add `yarn.lock` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@
 bower.json
 ember-cli-build.js
 testem.js
+yarn.lock
 
 # ember-try
 .node_modules.ember-try/


### PR DESCRIPTION
because it's huge and there is no need to distribute it to npm