### PR TITLE
Modify QUnit test name

### DIFF
--- a/addon/snapshot.js
+++ b/addon/snapshot.js
@@ -84,7 +84,7 @@ export function percySnapshot(name, options) {
 
   // Automatic name generation for QUnit tests by passing in the `assert` object.
   if (name.test && name.test.module && name.test.module.name && name.test.testName) {
-    name = `${name.test.module.name} | ${name.test.testName}`;
+    name = `${name.test.module.name}: ${name.test.testName}`;
   } else if (name.fullTitle) {
     // Automatic name generation for Mocha tests by passing in the `this.test` object.
     name = name.fullTitle();


### PR DESCRIPTION
## Why
Currently when I grab a snapshot name from the Percy UI and use it as a filter in QUnit it doesn't find the test. It would be nice to be able to copy/paste straight from the Percy UI into QUnit without modification to run a test.

## How
Currently when generating snapshots for QUnit, test names are generated like so:

```
Module name | Test name
```

QUnit test names actually take the following format (in 2.x anyway)

```
Module name: Test name
``` 

### Before
![image](https://user-images.githubusercontent.com/685034/42956109-0b50736c-8b77-11e8-9889-c4ff16e27238.png)

### After
![image](https://user-images.githubusercontent.com/685034/42956166-328a56be-8b77-11e8-86ed-0fa63e226a44.png)
