### PR TITLE
Update release notes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,16 @@
 # Releasing
 
+1. check that you are using the percy-admin npm account: `npm whoami`
+1. If you are not, sign out and sign as percy-admin
 1. `git checkout master`
 1. `git pull origin master`
+1. `git checkout -b x.x.x`
 1. `npm version x.x.x`
 1. `git push`
 1. `git push --tags`
-1. Ensure tests have passed on that tag
+1. Ensure tests have passed on that branch
+1. Open up a pull request titled with the new version number
+1. Merge approved pull request
 1. Draft and publish a [new release on github](https://github.com/percy/ember-percy/releases)
 1. `npm publish`
 1. [Visit NPM](https://www.npmjs.com/package/ember-percy) and see that your version is now live.


### PR DESCRIPTION
Update release notes to include logging into npm as percy-admin, and the new branch based merge method instead of pushing new versions directly to master.