### PR TITLE
chore: remove `ember-cli-htmlbars` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "dependencies": {
     "@percy/agent": "~0",
-    "ember-cli-babel": "^7.11.1",
-    "ember-cli-htmlbars": "^4.0.5"
+    "ember-cli-babel": "^7.11.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
@@ -32,6 +31,7 @@
     "ember-cli": "~3.14.0",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
+    "ember-cli-htmlbars": "^4.0.5",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-mirage": "^1.1.6",
     "ember-cli-sri": "^2.1.1",


### PR DESCRIPTION
Since this addon provides no templates, it doesn't have to ship the `ember-cli-htmlbars` as a dependency. This prevents it from being added to the dependencies of an installer of `ember-percy` if they are using an older version.

This is of particular note because `ember-cli-htmlbars` is new major version, meaning that an app still using `3.X.X` might need to install version 4.0 just for `ember-percy`, where it isn't actually used.