### PR TITLE
 feat: Use node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "qunit-dom": "^0.9.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">=10.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
_Potentially breaking release_, so tagged as a feature in case users need to pin to an older version rather than update unmaintained node