### PR TITLE
Fix types for QUnit use

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ type SnapshotFunction = (
 ) => Promise<void>;
 
 export const percySnapshot: SnapshotFunction;
+export default SnapshotFunction;
 
 declare global {
   // If QUnit types are present, the actual contents of its

--- a/types/tests/qunit-test.ts
+++ b/types/tests/qunit-test.ts
@@ -3,7 +3,7 @@
 // of the library typechecks and invalid usage produces errors.
 
 import { module, test } from 'qunit';
-import { percySnapshot } from '@percy/ember';
+import percySnapshot from '@percy/ember';
 
 module('Type declarations with QUnit', function() {
   test('snapshot requires at least one param', async function() {


### PR DESCRIPTION
## Problem

The tests introduced in #173 don't correctly reflect how you are supposed to import `percySnapshot` according to [the docs](https://docs.percy.io/docs/ember#section-setup).

This results in a type error when you try to use the function:

```
This expression is not callable.
Type 'typeof import(".../@percy/ember/types/index")' has no call signatures.
```

## Solution

Export a default to match how the the function `percySnapshot` is exported from `index.js`.
