### PR TITLE
Fix default type export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,8 +15,8 @@ type SnapshotFunction = (
   options?: SnapshotOptions
 ) => Promise<void>;
 
-export const percySnapshot: SnapshotFunction;
-export default SnapshotFunction;
+declare const percySnapshot: SnapshotFunction;
+export default percySnapshot;
 
 declare global {
   // If QUnit types are present, the actual contents of its


### PR DESCRIPTION
Sorry for the quick follow up to #195, but we actually need to export the `const` rather than the type. Since `index.js` no longer exports `percySnapshot` as a named export we don't need to export it as a named export here either.

I've verified locally this works so hopefully won't need another one of these 😄 