### PR TITLE
fix: Remove `#ember-testing` ID from cloned DOM

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -36,17 +36,7 @@ function clientInfo() {
 // This will only remove the transform applied by Ember's defaults
 // If there are custom styles applied, use Percy CSS to overwrite
 function removeEmberTestStyles(dom) {
-  dom
-    .querySelector('#ember-testing')
-    .setAttribute(
-      'style',
-      [
-        'width: initial !important',
-        'height: initial !important',
-        'transform: initial !important',
-        'zoom: initial !important'
-      ].join('; ')
-    );
+  dom.querySelector('#ember-testing').removeAttribute('id');
 }
 
 function autoGenerateName(name) {

--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -30,7 +30,7 @@ function envInfo() {
 }
 
 function clientInfo() {
-  return `@percy/ember@v2.1.2`;
+  return `@percy/ember@v2.1.3`;
 }
 
 // This will only remove the transform applied by Ember's defaults

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/ember",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "ember-addon"
   ],


### PR DESCRIPTION
## What is this?

This will be a much better method of removing the styles Ember adds to distort/shrink the app into the smaller test container. 

The previous way would set inline `!important` styles which can cause issues. It's just better to rip that attribute out that's setting the styles. 