### PR TITLE
fix: Update `width` type to be an array of numbers

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ interface SnapshotOptions {
   breakpoints?: string[];
   scope?: string;
   enableJavaScript?: boolean;
-  widths?: string[];
+  widths?: number[];
   domTransformation?: Function;
 }
 


### PR DESCRIPTION
## What is this?

Updates the widths type to be an array of numbers and not an array of strings. 