### PR TITLE
fix: Workaround for domTransformation error caused by empty document

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -105,6 +105,10 @@ export default async function percySnapshot(name, options = {}) {
     handleAgentCommunication: false,
     // We only want to capture the ember application, not the testing UI
     domTransformation: function(clonedDom) {
+      if (!clonedDom.querySelector(scopedSelector)) {
+        return clonedDom;
+      }
+
       if (options.domTransformation) {
         options.domTransformation(clonedDom);
       }


### PR DESCRIPTION
I'm not exactly sure why but `domTransformation` function is called 2 times for a single `percySnapshot` call. First time it's called with an empty `<html><body>` document so `hoistAppDom` fails with message like:

> ERROR: Could not transform the dom:  TypeError: Cannot read property 'innerHTML' of null

This is actually visible in the test log of this very project, for example this build (expand "Percy Test"): https://github.com/percy/ember-percy/runs/1055338113

Maybe there's a better fix for this but I'd really like to get rid of those annoying error logs 😅 