### PR TITLE
Update SnapshotOption to include `percyCSS`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ interface SnapshotOptions {
   enableJavaScript?: boolean;
   widths?: number[];
   domTransformation?: Function;
+  percyCSS?: string;
 }
 
 type SnapshotFunction = (


### PR DESCRIPTION
Adds missing `percyCSS` option to type defintion